### PR TITLE
Change kernel initialization

### DIFF
--- a/morphology.py
+++ b/morphology.py
@@ -13,8 +13,8 @@ class Morphology(nn.Module):
     def __init__(self, in_channels, out_channels, kernel_size=5, soft_max=True, beta=15, type=None):
         '''
         in_channels: scalar
-        out_channels: scalar, the number of the morpholigical neure. 
-        kernel_size: scalar, the spatial size of the morpholigical neure.
+        out_channels: scalar, the number of the morphological neure. 
+        kernel_size: scalar, the spatial size of the morphological neure.
         soft_max: bool, using the soft max rather the torch.max(), ref: Dense Morphological Networks: An Universal Function Approximator (Mondal et al. (2019)).
         beta: scalar, used by soft_max.
         type: str, dilation2d or erosion2d.

--- a/morphology.py
+++ b/morphology.py
@@ -27,7 +27,7 @@ class Morphology(nn.Module):
         self.beta = beta
         self.type = type
 
-        self.weight = nn.Parameter(torch.Tensor(out_channels, in_channels, kernel_size, kernel_size), requires_grad=True)
+        self.weight = nn.Parameter(torch.zeros(out_channels, in_channels, kernel_size, kernel_size), requires_grad=True)
         self.unfold = nn.Unfold(kernel_size, dilation=1, padding=0, stride=1)
 
     def forward(self, x):


### PR DESCRIPTION
Hi, and thanks for the useful work!

I found out that initializing the kernel with torch.Tensor() yields very unpredictable effects. The resulting kernel might contain non-zero values that are sometimes extremely high, leading to overflows in the subsequent computations.
I propose to explicitly initialize the kernel with torch.zeros()